### PR TITLE
Remove hardcoded path to r.js, rely on $PATH instead

### DIFF
--- a/wizkers/build-tools/build-chrome.sh
+++ b/wizkers/build-tools/build-chrome.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd dist/chrome-debug/www/js
-/opt/local/bin/r.js -o chrome.build.js
+r.js -o chrome.build.js

--- a/wizkers/build-tools/build-cordova.sh
+++ b/wizkers/build-tools/build-cordova.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd dist/cordova-debug/www/js
-/opt/local/bin/r.js -o cordova.build.js
+r.js -o cordova.build.js

--- a/wizkers/build-tools/build-nwjs.sh
+++ b/wizkers/build-tools/build-nwjs.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd dist/nwjs-debug/www/js
-/opt/local/bin/r.js -o nwjs.build.js
+r.js -o nwjs.build.js


### PR DESCRIPTION
The hardcoded path of `/opt/local/bin/r.js` in the build-tools files was causing me problems as my node's global install path is /usr/local, so I modified the shell scripts to remove the path and instead rely on users environment $PATH. 