### PR TITLE
patch - firmware 2.0.1 file path

### DIFF
--- a/wizkers/oem/nuclear/www/js/app/instruments/bluegiga/upgrader.js
+++ b/wizkers/oem/nuclear/www/js/app/instruments/bluegiga/upgrader.js
@@ -90,7 +90,7 @@ define(function (require) {
             $('#fw_dl', this.el).html('Downloading...').addClass('btn-warning');
             var xhr = new XMLHttpRequest();
             // Version 2.0.1
-            xhr.open('GET', 'https://www.dropbox.com/s/aqnxixx32hl6kz8/BLEBee-Firmware-BLE113-2.0.1-BLE-SDK1.3.2-b122.ota?dl=1', true);
+            xhr.open('GET', 'https://github.com/michaelkroll/BLEbee/blob/master/firmware/BLEbee-v2.0.1/BLEBee-Firmware-BLE113-2.0.1-BLE-SDK1.3.2-b122.ota', true);
             // Version 2.0.0
             //xhr.open('GET', 'https://www.dropbox.com/s/uh22hgfmxjp6n18/BLEBee-Firmware-BLE113-2.0.0-BLE-SDK1.3.2-b122.ota?dl=1', true);
             xhr.responseType = 'arraybuffer';


### PR DESCRIPTION
Firmware file for BLEBee is now missing on dropbox and it's not possible to actualize firmware through Drive app on android! I have replaced path for firmware file on official repository on github.